### PR TITLE
Overall Cleanup

### DIFF
--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -161,7 +161,7 @@ COSE_Encrypt0 is used then there is no AEAD function executed by COSE
 natively and HPKE offers this functionality.
 
 The "aad" parameter provided to the HPKE API is constructed
-as follows (and the design has been re-used from the COSE spec):
+as follows (and the design has been re-used from {{RFC9052}}):
 
 ~~~
 Enc_structure = [
@@ -169,6 +169,8 @@ Enc_structure = [
     protected : empty_or_serialized_map,
     external_aad : bstr
 ]
+
+empty_or_serialized_map = bstr .cbor header_map / bstr .size 0
 ~~~
 
 The protected field in the Enc_structure contains the protected attributes 

--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -49,6 +49,7 @@ normative:
 informative:
   RFC8937:
   RFC2630:
+  I-D.irtf-cfrg-dnhpke:
   HPKE-IANA:
      author:
         org: IANA
@@ -323,7 +324,7 @@ which authenticates using both a PSK and an asymmetric key.
 
 For a list of ciphersuite registrations, please see {{IANA}}. The following
 table summarizes the relationship between the ciphersuites registered in this
-document and maps them to the values from the HPKE IANA registry.
+document and the values registered in the HPKE IANA registry {{HPKE-IANA}}.
 
 ~~~
 +--------------------------------------------------+------------------+
@@ -342,8 +343,15 @@ document and maps them to the values from the HPKE IANA registry.
 | HPKE-Base-X448-SHA512-ChaCha20Poly1305           |0x21 | 0x3 | 0x3  |
 | HPKE-Base-X25519Kyber768-SHA256-AES256GCM        |0x30 | 0x1 | 0x2  |
 | HPKE-Base-X25519Kyber768-SHA256-ChaCha20Poly1305 |0x30 | 0x1 | 0x3  |
+| HPKE-Base-CP256-SHA256-ChaCha20Poly1305          |0x13 | 0x1 | 0x3  |
+| HPKE-Base-CP256-SHA256-AES128GCM                 |0x13 | 0x1 | 0x1  |
+| HPKE-Base-CP521-SHA512-ChaCha20Poly1305          |0x15 | 0x3 | 0x3  |
+| HPKE-Base-CP521-SHA512-AES256GCM                 |0x15 | 0x3 | 0x2  |
 +--------------------------------------------------+-----+-----+------+
 ~~~
+
+Note that the last four entries in the table refer to the compact encoding
+of the public keys defined in {{I-D.irtf-cfrg-dnhpke}}.
 
 As the list indicates, the ciphersuite labels have been abbreviated at least
 to some extend to maintain the tradeoff between readability and length.
@@ -371,7 +379,7 @@ to the following HPKE algorithm combination:
 
 ~~~
 16([
-    / alg = HPKE-Base-P256-SHA256-AES128GCM /
+    / alg = TBD1 (Assumed: 35) /
     h'a1011823',
     {
         / kid /
@@ -425,7 +433,7 @@ correspond to the following HPKE algorithm combination:
     h'',
     [
         [
-            / alg = HPKE-Base-P256-SHA256-AES128GCM /
+            / alg = TBD1 (Assumed: 35) /
             h'a1011823',
             {
                 / kid /
@@ -442,7 +450,7 @@ correspond to the following HPKE algorithm combination:
               c129b99a165cd5a28bd75859c10939b7e4d',
         ],
         [
-            / alg = HPKE-Base-P256-SHA256-AES128GCM /
+            / alg = TBD1 (Assumed: 35) /
             h'a1011823',
             {
                 / kid /
@@ -612,6 +620,39 @@ the 'COSE Header Parameters' registries.
 -  Reference:  [[TBD: This RFC]]
 -  Recommended: No
 
+-  Name: HPKE-Base-CP256-SHA256-ChaCha20Poly1305
+-  Value: TBD13 (Assumed: 45)
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(CP-256, HKDF-SHA256) KEM, the HKDF-SHA256 KDF and the ChaCha20Poly1305 AEAD.
+-  Capabilities: [kty]
+-  Change Controller: IESG
+-  Reference:  [[TBD: This RFC]]
+-  Recommended: Yes
+
+-  Name: HPKE-Base-CP521-SHA512-ChaCha20Poly1305
+-  Value: TBD14 (Assumed: 46)
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(CP-521, HKDF-SHA512) KEM, the HKDF-SHA512 KDF, and the ChaCha20Poly1305 AEAD.
+-  Capabilities: [kty]
+-  Change Controller: IESG
+-  Reference:  [[TBD: This RFC]]
+-  Recommended: Yes
+
+
+-  Name: HPKE-Base-CP256-SHA256-AES128GCM
+-  Value: TBD15 (Assumed: 47)
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(CP-256, HKDF-SHA256) KEM, the HKDF-SHA256 KDF and the AES128GCM AEAD.
+-  Capabilities: [kty]
+-  Change Controller: IESG
+-  Reference:  [[TBD: This RFC]]
+-  Recommended: Yes
+
+-  Name: HPKE-Base-CP521-SHA512-AES256GCM
+-  Value: TBD16 (Assumed: 47)
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(CP-521, HKDF-SHA512) KEM, the HKDF-SHA512 KDF, and the AES256GCM AEAD.
+-  Capabilities: [kty]
+-  Change Controller: IESG
+-  Reference:  [[TBD: This RFC]]
+-  Recommended: Yes
+
 ## COSE Header Parameters
 
 -  Name: encapsulated_key
@@ -627,7 +668,7 @@ the 'COSE Header Parameters' registries.
 
 We would like thank the following individuals for their contributions
 to the design of embedding the HPKE output into the COSE structure 
-following a long and lively mailing list discussion. 
+following a long and lively mailing list discussion:
 
 - Richard Barnes
 - Ilari Liusvaara

--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -326,22 +326,22 @@ table summarizes the relationship between the ciphersuites registered in this
 document and maps them to the values from the HPKE IANA registry.
 
 ~~~
-+-----------------------------------------------------+------------------+
-| COSE-HPKE                                           |      HPKE        |
-| Ciphersuite                                         | KEM | KDF | AEAD |
-+-----------------------------------------------------+-----+-----+------+
-| HPKE-v1-Base-P256-SHA256-AES128GCM                  |0x10 | 0x1 | 0x1  |
-| HPKE-v1-Base-P256-SHA256-ChaCha20Poly1305           |0x10 | 0x1 | 0x3  |
-| HPKE-v1-Base-P384-SHA384-AES256GCM                  |0x11 | 0x2 | 0x2  |
-| HPKE-v1-Base-P384-SHA384-ChaCha20Poly1305           |0x11 | 0x2 | 0x3  |
-| HPKE-v1-Base-P521-SHA512-AES256GCM                  |0x12 | 0x3 | 0x2  |
-| HPKE-v1-Base-P521-SHA512-ChaCha20Poly1305           |0x12 | 0x3 | 0x3  |
-| HPKE-v1-Base-X25519-SHA256-AES128GCM                |0x20 | 0x1 | 0x1  |
-| HPKE-v1-Base-X25519-SHA256-ChaCha20Poly1305         |0x20 | 0x1 | 0x3  |
-| HPKE-v1-Base-X448-SHA512-AES256GCM                  |0x21 | 0x3 | 0x2  |
-| HPKE-v1-Base-X448-SHA512-ChaCha20Poly1305           |0x21 | 0x3 | 0x3  |
-| HPKE-v1-Base-X25519Kyber768-SHA256-AES256GCM        |0x30 | 0x1 | 0x2  |
-| HPKE-v1-Base-X25519Kyber768-SHA256-ChaCha20Poly1305 |0x30 | 0x1 | 0x3  |
++--------------------------------------------------+------------------+
+| COSE-HPKE                                        |      HPKE        |
+| Ciphersuite                                      | KEM | KDF | AEAD |
++--------------------------------------------------+-----+-----+------+
+| HPKE-Base-P256-SHA256-AES128GCM                  |0x10 | 0x1 | 0x1  |
+| HPKE-Base-P256-SHA256-ChaCha20Poly1305           |0x10 | 0x1 | 0x3  |
+| HPKE-Base-P384-SHA384-AES256GCM                  |0x11 | 0x2 | 0x2  |
+| HPKE-Base-P384-SHA384-ChaCha20Poly1305           |0x11 | 0x2 | 0x3  |
+| HPKE-Base-P521-SHA512-AES256GCM                  |0x12 | 0x3 | 0x2  |
+| HPKE-Base-P521-SHA512-ChaCha20Poly1305           |0x12 | 0x3 | 0x3  |
+| HPKE-Base-X25519-SHA256-AES128GCM                |0x20 | 0x1 | 0x1  |
+| HPKE-Base-X25519-SHA256-ChaCha20Poly1305         |0x20 | 0x1 | 0x3  |
+| HPKE-Base-X448-SHA512-AES256GCM                  |0x21 | 0x3 | 0x2  |
+| HPKE-Base-X448-SHA512-ChaCha20Poly1305           |0x21 | 0x3 | 0x3  |
+| HPKE-Base-X25519Kyber768-SHA256-AES256GCM        |0x30 | 0x1 | 0x2  |
+| HPKE-Base-X25519Kyber768-SHA256-ChaCha20Poly1305 |0x30 | 0x1 | 0x3  |
 +-----------------------------------------------------+-----+-----+------+
 ~~~
 
@@ -359,7 +359,7 @@ An example of the COSE_Encrypt0 structure using the HPKE scheme is
 shown in {{hpke-example-one}}. Line breaks and comments have been inserted
 for better readability. 
 
-This example uses HPKE-v1-Base-P256-SHA256-AES128GCM as the algorithm,
+This example uses HPKE-Base-P256-SHA256-AES128GCM as the algorithm,
 which correspond to the following HPKE algorithm combination:
 
 - KEM: DHKEM(P-256, HKDF-SHA256)
@@ -371,7 +371,7 @@ which correspond to the following HPKE algorithm combination:
 
 ~~~
 16([
-    / alg = HPKE-v1-Base-P256-SHA256-AES128GCM /
+    / alg = HPKE-Base-P256-SHA256-AES128GCM /
     h'a1011823',
     {
         / kid /
@@ -405,7 +405,7 @@ This example uses AES-128-GCM for encryption of the plaintext
 detached.
 
 At the recipient structure at layer 1, this example uses
-HPKE-v1-Base-P256-SHA256-AES128GCM as the algorithm, which
+HPKE-Base-P256-SHA256-AES128GCM as the algorithm, which
 correspond to the following HPKE algorithm combination:
 
 - KEM: DHKEM(P-256, HKDF-SHA256)
@@ -425,7 +425,7 @@ correspond to the following HPKE algorithm combination:
     h'',
     [
         [
-            / alg = HPKE-v1-Base-P256-SHA256-AES128GCM /
+            / alg = HPKE-Base-P256-SHA256-AES128GCM /
             h'a1011823',
             {
                 / kid /
@@ -442,7 +442,7 @@ correspond to the following HPKE algorithm combination:
               c129b99a165cd5a28bd75859c10939b7e4d',
         ],
         [
-            / alg = HPKE-v1-Base-P256-SHA256-AES128GCM /
+            / alg = HPKE-Base-P256-SHA256-AES128GCM /
             h'a1011823',
             {
                 / kid /
@@ -517,97 +517,97 @@ With Expert Review category.
 
 ## COSE Algorithms Registry
 
--  Name: HPKE-v1-Base-P256-SHA256-AES128GCM
+-  Name: HPKE-Base-P256-SHA256-AES128GCM
 -  Value: TBD1 (Assumed: 35)
--  Description: Cipher suite for COSE-HPKE version 1 in Base Mode that uses the DHKEM(P-256, HKDF-SHA256) KEM, the HKDF-SHA256 KDF and the AES-128-GCM AEAD.
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(P-256, HKDF-SHA256) KEM, the HKDF-SHA256 KDF and the AES-128-GCM AEAD.
 -  Capabilities: [kty]
 -  Change Controller: IESG
 -  Reference:  [[TBD: This RFC]]
 -  Recommended: Yes
 
--  Name: HPKE-v1-Base-P256-SHA256-ChaCha20Poly1305
+-  Name: HPKE-Base-P256-SHA256-ChaCha20Poly1305
 -  Value: TBD2 (Assumed: 36)
--  Description: Cipher suite for COSE-HPKE version 1 in Base Mode that uses the DHKEM(P-256, HKDF-SHA256) KEM, the HKDF-SHA256 KDF and the ChaCha20Poly1305 AEAD.
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(P-256, HKDF-SHA256) KEM, the HKDF-SHA256 KDF and the ChaCha20Poly1305 AEAD.
 -  Capabilities: [kty]
 -  Change Controller: IESG
 -  Reference:  [[TBD: This RFC]]
 -  Recommended: Yes
 
--  Name: HPKE-v1-Base-P384-SHA384-AES256GCM
+-  Name: HPKE-Base-P384-SHA384-AES256GCM
 -  Value: TBD3 (Assumed: 37)
--  Description: Cipher suite for COSE-HPKE version 1 in Base Mode that uses the DHKEM(P-384, HKDF-SHA384) KEM, the HKDF-SHA384 KDF, and the AES-256-GCM AEAD.
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(P-384, HKDF-SHA384) KEM, the HKDF-SHA384 KDF, and the AES-256-GCM AEAD.
 -  Capabilities: [kty]
 -  Change Controller: IESG
 -  Reference:  [[TBD: This RFC]]
 -  Recommended: Yes
 
--  Name: HPKE-v1-Base-P384-SHA384-ChaCha20Poly1305
+-  Name: HPKE-Base-P384-SHA384-ChaCha20Poly1305
 -  Value: TBD4 (Assumed: 38)
--  Description: Cipher suite for COSE-HPKE version 1 in Base Mode that uses the DHKEM(P-384, HKDF-SHA384) KEM, the HKDF-SHA384 KDF, and the ChaCha20Poly1305 AEAD.
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(P-384, HKDF-SHA384) KEM, the HKDF-SHA384 KDF, and the ChaCha20Poly1305 AEAD.
 -  Capabilities: [kty]
 -  Change Controller: IESG
 -  Reference:  [[TBD: This RFC]]
 -  Recommended: Yes
 
--  Name: HPKE-v1-Base-P521-SHA512-AES256GCM
+-  Name: HPKE-Base-P521-SHA512-AES256GCM
 -  Value: TBD5 (Assumed: 39)
--  Description: Cipher suite for COSE-HPKE version 1 in Base Mode that uses the DHKEM(P-521, HKDF-SHA512) KEM, the HKDF-SHA512 KDF, and the AES-256-GCM AEAD.
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(P-521, HKDF-SHA512) KEM, the HKDF-SHA512 KDF, and the AES-256-GCM AEAD.
 -  Capabilities: [kty]
 -  Change Controller: IESG
 -  Reference:  [[TBD: This RFC]]
 -  Recommended: Yes
 
--  Name: HPKE-v1-Base-P521-SHA512-ChaCha20Poly1305
+-  Name: HPKE-Base-P521-SHA512-ChaCha20Poly1305
 -  Value: TBD6 (Assumed: 40)
--  Description: Cipher suite for COSE-HPKE version 1 in Base Mode that uses the DHKEM(P-521, HKDF-SHA512) KEM, the HKDF-SHA512 KDF, and the ChaCha20Poly1305 AEAD.
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(P-521, HKDF-SHA512) KEM, the HKDF-SHA512 KDF, and the ChaCha20Poly1305 AEAD.
 -  Capabilities: [kty]
 -  Change Controller: IESG
 -  Reference:  [[TBD: This RFC]]
 -  Recommended: Yes
 
--  Name: HPKE-v1-Base-X25519-SHA256-AES128GCM
+-  Name: HPKE-Base-X25519-SHA256-AES128GCM
 -  Value: TBD7 (Assumed: 41)
--  Description: Cipher suite for COSE-HPKE version 1 in Base Mode that uses the DHKEM(X25519, HKDF-SHA256) KEM, the HKDF-SHA256 KDF, and the AES-128-GCM AEAD.
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(X25519, HKDF-SHA256) KEM, the HKDF-SHA256 KDF, and the AES-128-GCM AEAD.
 -  Capabilities: [kty]
 -  Change Controller: IESG
 -  Reference:  [[TBD: This RFC]]
 -  Recommended: Yes
 
--  Name: HPKE-v1-Base-X25519-SHA256-ChaCha20Poly1305
+-  Name: HPKE-Base-X25519-SHA256-ChaCha20Poly1305
 -  Value: TBD8 (Assumed: 42)
--  Description: Cipher suite for COSE-HPKE version 1 in Base Mode that uses the DHKEM(X25519, HKDF-SHA256) KEM, the HKDF-SHA256 KDF, and the ChaCha20Poly1305 AEAD.
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(X25519, HKDF-SHA256) KEM, the HKDF-SHA256 KDF, and the ChaCha20Poly1305 AEAD.
 -  Capabilities: [kty]
 -  Change Controller: IESG
 -  Reference:  [[TBD: This RFC]]
 -  Recommended: Yes
 
--  Name: HPKE-v1-Base-X448-SHA512-AES256GCM
+-  Name: HPKE-Base-X448-SHA512-AES256GCM
 -  Value: TBD9 (Assumed: 43)
--  Description: Cipher suite for COSE-HPKE version 1 in Base Mode that uses the DHKEM(X448, HKDF-SHA512) KEM, the HKDF-SHA512 KDF, and the AES-256-GCM AEAD.
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(X448, HKDF-SHA512) KEM, the HKDF-SHA512 KDF, and the AES-256-GCM AEAD.
 -  Capabilities: [kty]
 -  Change Controller: IESG
 -  Reference:  [[TBD: This RFC]]
 -  Recommended: Yes
 
--  Name: HPKE-v1-Base-X448-SHA512-ChaCha20Poly1305
+-  Name: HPKE-Base-X448-SHA512-ChaCha20Poly1305
 -  Value: TBD10 (Assumed: 44)
--  Description: Cipher suite for COSE-HPKE version 1 in Base Mode that uses the DHKEM(X448, HKDF-SHA512) KEM, the HKDF-SHA512 KDF, and the ChaCha20Poly1305 AEAD.
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(X448, HKDF-SHA512) KEM, the HKDF-SHA512 KDF, and the ChaCha20Poly1305 AEAD.
 -  Capabilities: [kty]
 -  Change Controller: IESG
 -  Reference:  [[TBD: This RFC]]
 -  Recommended: Yes
 
--  Name: HPKE-v1-Base-X25519Kyber768-SHA256-AES256GCM
+-  Name: HPKE-Base-X25519Kyber768-SHA256-AES256GCM
 -  Value: TBD11 (Assumed: 250)
--  Description: Cipher suite for COSE-HPKE version 1 in Base Mode that uses the X25519Kyber768Draft00 KEM, the HKDF-SHA256 KDF, and the AES-256-GCM AEAD.
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the X25519Kyber768Draft00 KEM, the HKDF-SHA256 KDF, and the AES-256-GCM AEAD.
 -  Capabilities: [kty]
 -  Change Controller: IESG
 -  Reference:  [[TBD: This RFC]]
 -  Recommended: No
 
--  Name: HPKE-v1-Base-X25519Kyber768-SHA256-ChaCha20Poly1305
+-  Name: HPKE-Base-X25519Kyber768-SHA256-ChaCha20Poly1305
 -  Value: TBD12 (Assumed: 251)
--  Description: Cipher suite for COSE-HPKE version 1 in Base Mode that uses the X25519Kyber768Draft00 KEM, the HKDF-SHA256 KDF, and the ChaCha20Poly1305 AEAD.
+-  Description: Cipher suite for COSE-HPKE in Base Mode that uses the X25519Kyber768Draft00 KEM, the HKDF-SHA256 KDF, and the ChaCha20Poly1305 AEAD.
 -  Capabilities: [kty]
 -  Change Controller: IESG
 -  Reference:  [[TBD: This RFC]]

--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -328,7 +328,7 @@ document and maps them to the values from the HPKE IANA registry.
 ~~~
 +--------------------------------------------------+------------------+
 | COSE-HPKE                                        |      HPKE        |
-| Ciphersuite                                      | KEM | KDF | AEAD |
+| Cipher Suite Label                               | KEM | KDF | AEAD |
 +--------------------------------------------------+-----+-----+------+
 | HPKE-Base-P256-SHA256-AES128GCM                  |0x10 | 0x1 | 0x1  |
 | HPKE-Base-P256-SHA256-ChaCha20Poly1305           |0x10 | 0x1 | 0x3  |
@@ -342,7 +342,7 @@ document and maps them to the values from the HPKE IANA registry.
 | HPKE-Base-X448-SHA512-ChaCha20Poly1305           |0x21 | 0x3 | 0x3  |
 | HPKE-Base-X25519Kyber768-SHA256-AES256GCM        |0x30 | 0x1 | 0x2  |
 | HPKE-Base-X25519Kyber768-SHA256-ChaCha20Poly1305 |0x30 | 0x1 | 0x3  |
-+-----------------------------------------------------+-----+-----+------+
++--------------------------------------------------+-----+-----+------+
 ~~~
 
 As the list indicates, the ciphersuite labels have been abbreviated at least
@@ -357,10 +357,10 @@ encrypted payload to a single recipient in the most efficient way.
 
 An example of the COSE_Encrypt0 structure using the HPKE scheme is
 shown in {{hpke-example-one}}. Line breaks and comments have been inserted
-for better readability. 
+for better readability.
 
-This example uses HPKE-Base-P256-SHA256-AES128GCM as the algorithm,
-which correspond to the following HPKE algorithm combination:
+This example uses HPKE-Base-P256-SHA256-AES128GCM, which corresponds
+to the following HPKE algorithm combination:
 
 - KEM: DHKEM(P-256, HKDF-SHA256)
 - KDF: HKDF-SHA256
@@ -512,8 +512,7 @@ but may not be guaranteed by non-AEAD ciphers.
 #  IANA Considerations {#IANA}
 
 This document requests IANA to add new values to the 'COSE Algorithms' and to 
-the 'COSE Header Parameters' registries in the 'Standards Action 
-With Expert Review category.
+the 'COSE Header Parameters' registries.
 
 ## COSE Algorithms Registry
 


### PR DESCRIPTION
In this PR I did an overall cleanup:

* added an explanation about the ciphersuite allocation,
* text describing the aad and info parameters for COSE_Encrypt0 (but not yet for COSE_Encrypt), [This is old text]
* cleaned up remaining text about doc being "base mode" only (but nothing registered yet in terms of ciphersuites)
* Removed version number from ciphertext string (see https://github.com/cose-wg/HPKE/issues/34)

I also improved the wording of the text in the intro and the abstract.

@dajiaji @selfissued @laurencelundblade @OR13 @ilaril: Please have a quick look at it.