### PR TITLE
Replace COSE_KDF_Context with new Recipient structure

### DIFF
--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -213,7 +213,7 @@ The COSE_KDF_Context MUST NOT be used in COSE-HPKE.
 
 ~~~
 Recipient_structure = [ 
-    context: “Recipient”,
+    context: "Recipient",
     next_layer_alg: int/tstr,
     recipient_protected_header: empty_or_serialize_map,
     recipient_aad: bstr

--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -241,7 +241,7 @@ It provides a means to convey many of the fields in COSE_KDF_Context.
 This is the procedure for creating a COSE_recipient for COSE-HPKE.
 
 When a COSE_recipeint is constructed for a COSE-HPKE recipient, this is given as the “aad” parameter to the HPKE Seal() API.
-The “info” parameter to HPKE_Seal is not used with COSE_HPKE.
+The "info" parameter to HPKE_Seal is not used with COSE_HPKE.
 
 The creation of the COSE_recipient is as follows:
 

--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -45,6 +45,7 @@ normative:
   RFC9180:
   RFC9052:
   RFC9053:
+  STD94:
   
 informative:
   RFC8937:
@@ -225,7 +226,7 @@ This MUST match the alg parameter in the next lower COSE layer.
 (This serves the same purpose as the alg ID in the COSE_KDF_Context.
 It also mitigates attacks where a man-in-the-middle changes the following layer algorithm from an AEAD algorithm to one that is not foiling the protection of the following layer headers).
 
-- "recipient_protected_header" This is the protected headers from the COSE_recipient CBOR-encoded deterministically with CDE.
+- "recipient_protected_header" This is the protected headers from the COSE_recipient CBOR-encoded deterministically with Core Deterministic Encoding Requirements specified in Section 4.2.1 of RFC 8949 {{STD94}}.
 
 - "recipient_aad" This is any additional context that the application wishes to protect.
 If none, it is a zero-length string.

--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -220,8 +220,8 @@ Recipient_structure = [ 
 ~~~
 
 
-- "next_layer_alg" is the algorithm ID of the COSE layer for which the COSE_recipient is providing a key.
-It is the algorithm that the key MUST be used for.
+- "next_layer_alg" is the algorithm ID of the COSE layer for which the COSE_recipient is encrypting a key.
+It is the algorithm that the key MUST be used with.
 This MUST match the alg parameter in the next lower COSE layer.
 (This serves the same purpose as the alg ID in the COSE_KDF_Context.
 It also mitigates attacks where a man-in-the-middle changes the following layer algorithm from an AEAD algorithm to one that is not foiling the protection of the following layer headers).
@@ -304,26 +304,6 @@ The COSE_Encrypt MAY be tagged or untagged.
 When encrypting the content at layer 0 then the instructions in
 Section 5.3 of {{RFC9052}} MUST to be followed, which includes the
 calculation of the authenticated data strcture.
-
-At layer 1 where HPKE is used to encrypt the CEK, the "aad" parameter
-provided to the HPKE API is constructed as follows (and the design has
-been re-used from {{RFC9052}}):
-
-~~~
-Enc_structure = [
-    context : "Enc_Recipient",
-    protected : empty_or_serialized_map,
-    external_aad : bstr
-]
-
-empty_or_serialized_map = bstr .cbor header_map / bstr .size 0
-~~~
-
-The protected field in the Enc_structure contains the protected attributes 
-from the COSE_recipient structure at layer 1, encoded in a bstr type.
-
-The HPKE APIs also use an "info" parameter as input and the details are
-provided in {{info}}.
 
 An example is shown in {{two-layer-example}}.
 
@@ -503,6 +483,8 @@ shown in {{hpke-example-cose-encrypt}}. Line breaks and comments have been
 inserted for better readability. 
 
 This example uses the following:
+
+TODO: recompute this for Recipient_structure
 
 - Encryption alg: AES-128-GCM
 - plaintext: "This is the content."

--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -226,7 +226,7 @@ This value MUST match the alg parameter in the next lower COSE layer.
 (This serves the same purpose as the alg ID in the COSE_KDF_Context.
 It also mitigates attacks where a person-in-the-middle changes the following layer algorithm from an AEAD algorithm to one that is not foiling the protection of the following layer headers).
 
-- "recipient_protected_header" This is the protected headers from the COSE_recipient CBOR-encoded deterministically with Core Deterministic Encoding Requirements specified in Section 4.2.1 of RFC 8949 {{STD94}}.
+- "recipient_protected_header" contains the protected headers from the COSE_recipient CBOR-encoded deterministically with the "Core Deterministic Encoding Requirements", specified in Section 4.2.1 of RFC 8949 {{STD94}}.
 
 - "recipient_aad" contains any additional context the application wishes to protect.
 If none, it is a zero-length string.

--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -240,7 +240,7 @@ It provides a means to convey many of the fields in COSE_KDF_Context.
 
 This is the procedure for creating a COSE_recipient for COSE-HPKE.
 
-When a COSE_recipeint is constructed for a COSE-HPKE recipient, this is given as the “aad” parameter to the HPKE Seal() API.
+When a COSE_recipeint is constructed for a COSE-HPKE recipient, this is given as the "aad" parameter to the HPKE Seal() API.
 The "info" parameter to HPKE_Seal is not used with COSE_HPKE.
 
 The creation of the COSE_recipient is as follows:

--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -228,7 +228,7 @@ It also mitigates attacks where a person-in-the-middle changes the following lay
 
 - "recipient_protected_header" This is the protected headers from the COSE_recipient CBOR-encoded deterministically with Core Deterministic Encoding Requirements specified in Section 4.2.1 of RFC 8949 {{STD94}}.
 
-- "recipient_aad" This is any additional context that the application wishes to protect.
+- "recipient_aad" contains any additional context the application wishes to protect.
 If none, it is a zero-length string.
 This is distinct from the external_aad for the whole COSE encrypt.
 It is per-recipient.

--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -204,11 +204,11 @@ As stated above, the specification uses a CEK to encrypt the content at layer 0.
 
 #### Recipient Encryption
 
-This describes a Recipient_structure.
+This describes the Recipient_structure.
 It serves instead of COSE_KDF_Context for COSE-HPKE recipients (and possibly other COSE algorithms defined outside this document).
-It is mandatory for COSE-HPKE recipients as it provides the protection for protected headers.
-It is patterned after the Enc_structure in RFC 9052, but is specifically for a COSE_recipient, never a COSE_Encrypt.
-The COSE_KDF_Context is NOT used in COSE-HPKE.
+It MUST be used for COSE-HPKE recipients as it provides the protection for recipient protected headers.
+It is patterned after the Enc_structure in {{RFC9052}}, but is specifically for a COSE_recipient, never a COSE_Encrypt.
+The COSE_KDF_Context MUST NOT be used in COSE-HPKE.
 
 ~~~
 Recipient_structure = [ 
@@ -218,7 +218,6 @@ Recipient_structure = [ 
     recipient_aad: bstr
 ]
 ~~~
-
 
 - "next_layer_alg" is the algorithm ID of the COSE layer for which the COSE_recipient is encrypting a key.
 It is the algorithm that the key MUST be used with.
@@ -231,7 +230,8 @@ It also mitigates attacks where a man-in-the-middle changes the following layer 
 - "recipient_aad" This is any additional context that the application wishes to protect.
 If none, it is a zero-length string.
 This is distinct from the external_aad for the whole COSE encrypt.
-It is per-recipient. Since it is not a header, it may be secret data that is not transmitted.
+It is per-recipient.
+Since it is not a header, it may be secret data that is not transmitted.
 It provides a means to convey many of the fields in COSE_KDF_Context.
 
 
@@ -245,12 +245,12 @@ The “info” parameter to HPKE_Seal is not used with COSE_HPKE.
 The creation of the COSE_recipient is as follows:
 
 1. Prepare a Recipient_structure
-2. Obtain the CEK from the next lowest layer
+2. Obtain the key To used use by the next lowest layer
 3. Pass in the following parameters to HPKE Seal API
     1. Public key of recipient for “pKR”
     2. Empty string for “info”
     3. CBOR-encoded Recipient_structure for “aad”
-    4. CEK for next cose layer for “pt”
+    4. The key for next lowest COSE layer for “pt”
 4.  The following are returned from the HPKE Seal API
     1. The “enc” is placed in the "ek" header of the COSE_recipient
     2. The “ct” is placed in the “ciphertext” field of the COSE_recipient
@@ -264,12 +264,11 @@ The decoding and decryption of a COSE_recipient is as follows:
     3. Empty string for “info”
     4. CBOR-encoded Recipient_structure for “aad”
     5. The cipher text from the COSE_recipient as “ct”
-3. What is returned from HPKE Open API is the CEK for the next COSE layer
+3. What is returned from HPKE Open API is the key for the next lowest COSE layer
 
-It is not necessary to fill in recipeint_aad as HPKE itself covers the attacks that recipient_aad (and COSE_KDF_Context (and xxxx reference)) are used to mitigate.
+It is not necessary to fill in recipeint_aad as HPKE itself covers the attacks that recipient_aad (and COSE_KDF_Context (and SP800-56A)) are used to mitigate.
 COSE-HPKE use cases may use it for any purpose they wish, but it should generally be for small identifiers, context or secrets, not to protect bulk external data.
 Bulk external data should be protected at layer 0 with external_aad.
-
 
 
 The COSE_recipient structure, shown in {{cddl-hpke}}, is repeated for each
@@ -718,7 +717,9 @@ mechanism is assumed to exist but outside the scope of this document.
 
 HPKE relies on a source of randomness to be available on the device. Additionally, 
 with the two layer structure the CEK is randomly generated and it MUST be
-ensured that the guidelines in {{RFC8937}} for random number generations are followed. 
+ensured that the guidelines in {{RFC8937}} for random number generations are followed.
+
+TODO: 
 
 HPKE in Base mode does not offer authentication as part of the HPKE KEM. In this
 case COSE constructs like COSE_Sign, COSE_Sign1, COSE_MAC, or COSE_MAC0 can be

--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -248,23 +248,23 @@ The creation of the COSE_recipient is as follows:
 1. Prepare a Recipient_structure
 2. Obtain the key To used use by the next lowest layer
 3. Pass in the following parameters to HPKE Seal API
-    1. Public key of recipient for “pKR”
-    2. Empty string for “info”
-    3. CBOR-encoded Recipient_structure for “aad”
-    4. The key for next lowest COSE layer for “pt”
+    1. Public key of recipient for "pKR"
+    2. Empty string for "info"
+    3. CBOR-encoded Recipient_structure for "aad"
+    4. The key for next lowest COSE layer for "pt"
 4.  The following are returned from the HPKE Seal API
-    1. The “enc” is placed in the "ek" header of the COSE_recipient
-    2. The “ct” is placed in the “ciphertext” field of the COSE_recipient
+    1. The "enc" is placed in the "ek" header of the COSE_recipient
+    2. The "ct" is placed in the "ciphertext" field of the COSE_recipient
 
 The decoding and decryption of a COSE_recipient is as follows:
 
 1. Prepare a Recipient_structure
 2. Pass in the following parameters to HPKE Open API
-    1. The "ek" header  for “enc”
-    2. Secret key for recipient for “sKR”
-    3. Empty string for “info”
-    4. CBOR-encoded Recipient_structure for “aad”
-    5. The cipher text from the COSE_recipient as “ct”
+    1. The "ek" header  for "enc"
+    2. Secret key for recipient for "sKR"
+    3. Empty string for "info"
+    4. CBOR-encoded Recipient_structure for "aad"
+    5. The cipher text from the COSE_recipient as "ct"
 3. What is returned from HPKE Open API is the key for the next lowest COSE layer
 
 It is not necessary to fill in recipient_aad as HPKE itself covers the attacks that recipient_aad (and COSE_KDF_Context (and SP800-56A)) are used to mitigate.

--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -222,7 +222,7 @@ Recipient_structure = [ 
 
 - "next_layer_alg" is the algorithm ID of the COSE layer for which the COSE_recipient is encrypting a key.
 It is the algorithm that the key MUST be used with.
-This MUST match the alg parameter in the next lower COSE layer.
+This value MUST match the alg parameter in the next lower COSE layer.
 (This serves the same purpose as the alg ID in the COSE_KDF_Context.
 It also mitigates attacks where a man-in-the-middle changes the following layer algorithm from an AEAD algorithm to one that is not foiling the protection of the following layer headers).
 

--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -224,7 +224,7 @@ Recipient_structure = [ 
 It is the algorithm that the key MUST be used with.
 This value MUST match the alg parameter in the next lower COSE layer.
 (This serves the same purpose as the alg ID in the COSE_KDF_Context.
-It also mitigates attacks where a man-in-the-middle changes the following layer algorithm from an AEAD algorithm to one that is not foiling the protection of the following layer headers).
+It also mitigates attacks where a person-in-the-middle changes the following layer algorithm from an AEAD algorithm to one that is not foiling the protection of the following layer headers).
 
 - "recipient_protected_header" This is the protected headers from the COSE_recipient CBOR-encoded deterministically with Core Deterministic Encoding Requirements specified in Section 4.2.1 of RFC 8949 {{STD94}}.
 


### PR DESCRIPTION
This is my attempt at the outcome of the discussion between Ori, Illari and myself on the list.

I went back to next_alg so it can be used with multiple layers of COSE_Recipient, but say that it is for the next *COSE* layer down. It is expected that when a COSE_Recipient employs multiple algorithms like HPKE and -29 do that they lock down all the algorithms they use internally. It was unclear what the alg ID in COSE_KDF_Context was for.

I haven't implemented this, but I'm pretty confident about it. I also haven't updated the examples.