### PR TITLE
Update defaults for 'info' and 'aad' fields

### DIFF
--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -160,8 +160,6 @@ When encrypting, the inputs to the HPKE Seal operation are set as follows:
 - aad: MUST contain the byte string for the authenticated data structure according to the steps defined in Section 5.3 of RFC 9052.
 For the Integrated Encryption mode the context string will be "Encrypt0".
 - aead_id: Depends on the COSE-HPKE algorithm used.
-- info: Defaults to the empty string; externally provided information MAY be used instead.
-- aad: Defaults to the empty string; externally provided information MAY be used instead.
 - pt: The raw message plaintext.
 
 The outputs are used as follows:


### PR DESCRIPTION
Clarify defaults for 'info' and 'aad' fields in COSE-HPKE.