### PR TITLE
Update AAD information handling in Integrated Encryption

### DIFF
--- a/draft-ietf-cose-hpke.md
+++ b/draft-ietf-cose-hpke.md
@@ -165,7 +165,8 @@ When encrypting, the inputs to the HPKE Seal operation are set as follows:
 - kdf_id: Depends on the COSE-HPKE algorithm used.
 - info: Defaults to the empty string; externally provided information MAY be used instead.
 - aad: MUST contain the byte string for the authenticated data structure according to the steps defined in Section 5.3 of RFC 9052.
-For the Integrated Encryption mode the context string will be "Encrypt0". Externally provided AAD information MAY be provided and MUST be passed into the Enc_structure via the external_aad field.
+For the Integrated Encryption mode the context string will be "Encrypt0".
+Externally provided AAD information MAY be provided and MUST be passed into the Enc_structure via the external_aad field.
 - aead_id: Depends on the COSE-HPKE algorithm used.
 - pt: The raw message plaintext.
 


### PR DESCRIPTION
Clarified the use of externally provided AAD information in the Integrated Encryption mode and noted that it must be passed into the external_aad field of the Enc_structure.

This part was left unspecified and not allowing externally supplied AAD information creates an imbalance with the HPKE Key Encryption mode.